### PR TITLE
chore: don't major bump nodeJs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,6 +40,13 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "description": "Disable major bump PRs for the 'node' dependencies",
+      "matchPackageNames": [
+        "node"
+      ],
+      "major": false
     }
   ],
   "dockerfile": {


### PR DESCRIPTION
This PR aims to disable Renovate-Bot constantly trying to major bump NodeJs.