### PR TITLE
Added CommonLabels

### DIFF
--- a/uptime-kuma/Chart.yaml
+++ b/uptime-kuma/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/uptime-kuma/readme.adoc
+++ b/uptime-kuma/readme.adoc
@@ -210,3 +210,8 @@ CAUTION: Be sure you know what you are doing before making changes here.
 |Allows you to overwrite the name property to a predefined value.
 |===
 
+|`commonLabels`
+|`""`
+|Allows you to add labels that you want on every resource.
+|===
+

--- a/uptime-kuma/templates/_helpers.tpl
+++ b/uptime-kuma/templates/_helpers.tpl
@@ -37,6 +37,9 @@ Common labels
 {{- define "uptime-kuma.labels" -}}
 helm.sh/chart: {{ include "uptime-kuma.chart" . }}
 {{ include "uptime-kuma.selectorLabels" . }}
+{{- with .Values.commonLabels }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}

--- a/uptime-kuma/templates/ingress.yaml
+++ b/uptime-kuma/templates/ingress.yaml
@@ -10,12 +10,18 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
+    {{- with .Values.ingress.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/uptime-kuma/templates/pvc.yaml
+++ b/uptime-kuma/templates/pvc.yaml
@@ -11,6 +11,8 @@ metadata:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
     {{- with .Values.persistence.labels }}
     {{- toYaml . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   accessModes:

--- a/uptime-kuma/templates/route.yaml
+++ b/uptime-kuma/templates/route.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
     {{- with .Values.route.labels }}
     {{- toYaml . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
     {{- with .Values.route.annotations }}

--- a/uptime-kuma/templates/service.yaml
+++ b/uptime-kuma/templates/service.yaml
@@ -4,6 +4,12 @@ metadata:
   name: {{ include "uptime-kuma.fullname" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/uptime-kuma/templates/serviceaccount.yaml
+++ b/uptime-kuma/templates/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "uptime-kuma.serviceAccountName" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/uptime-kuma/templates/statefulSet.yaml
+++ b/uptime-kuma/templates/statefulSet.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
     {{- with .Values.statefulSet.labels }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}  
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
     {{- with .Values.statefulSet.annotations }}
@@ -17,6 +20,9 @@ spec:
   selector:
     matchLabels:
       {{- include "uptime-kuma.selectorLabels" . | nindent 6 }}
+      {{- with .Values.commonLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -25,6 +31,9 @@ spec:
       {{- end }}
       labels:
         {{- include "uptime-kuma.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/uptime-kuma/values.yaml
+++ b/uptime-kuma/values.yaml
@@ -13,6 +13,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+commonlabels: {}
+
 statefulSet:
   labels: {}
   annotations: {}


### PR DESCRIPTION
Added CommonLabels as suggested in #126 

You can add them optionally offcourse using 
```
commonLabels: {
  group: 'kuma'
}
```

There is a small extension eeded after this Pr is merged to add the labels there too:
https://github.com/k3rnelpan1c-dev/uptime-kuma-helm/issues/125