### PR TITLE
fix: apprise install after bookworm update

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -25,7 +25,6 @@ RUN apt-get update -qqy \
         python3-markdown \
         python3-requests \
         python3-requests-oauthlib \
-        pipx \
         sqlite3 \
         iputils-ping \
         util-linux \
@@ -33,7 +32,7 @@ RUN apt-get update -qqy \
         curl \
         ca-certificates \
         bash \
-    && pipx install --pip-args '--no-cache-dir' apprise==${APPRISE_VERSION} \
+    && pip --no-cache-dir install --break-system-packages apprise==${APPRISE_VERSION} \
     && rm -rf /var/lib/apt/lists/* \
     \
     # Download and install cloudflared

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -16,9 +16,24 @@ COPY --from=app-donor /app /app
 RUN apt-get update -qqy \
     # Install Uptime-Kuma dependencies
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy \
-        python3 python3-pip python3-cryptography python3-six python3-yaml python3-click python3-markdown python3-requests python3-requests-oauthlib \
-        sqlite3 iputils-ping util-linux dumb-init curl ca-certificates bash \
-    && pip3 --no-cache-dir install apprise==${APPRISE_VERSION} \
+        python3 \
+        python3-pip \
+        python3-cryptography \
+        python3-six \
+        python3-yaml \
+        python3-click \
+        python3-markdown \
+        python3-requests \
+        python3-requests-oauthlib \
+        pipx \
+        sqlite3 \
+        iputils-ping \
+        util-linux \
+        dumb-init \
+        curl \
+        ca-certificates \
+        bash \
+    && pipx install --pip-args '--no-cache-dir' apprise==${APPRISE_VERSION} \
     && rm -rf /var/lib/apt/lists/* \
     \
     # Download and install cloudflared


### PR DESCRIPTION
This PR aims to fix the Apprise install after the move to Bookworm (Debian 12).
With Debian 12 comes Python 3.11 and [PEP-668](https://peps.python.org/pep-0668/), which means that installing Debian's Python system package has the _"externally managed environments"_ set.

There are basically 2 paths to circumvent this causing errors:
* utilise pip's `--break-system-packages` flag (keeps the old behaviour how I installed `apprise`)
* use a `venv` as PEP-668 intents to nag you to do.

I attempted the latter, however, since I never really worked with venv nor claim to be a python crack in general I was unable to get it to work within the limited time I had available to invest in this update.
Similarly, I had no luck with attempting to use `pipx`, which abstracts away the `venv` for you, but then fails to make `apprise` available system wide.
Finally, I opted to use the `--break-system-packages` flag, as the impact of installing `apprise` is foreseeable and we live within a container anyway.

If anyone finds this PR and wants to contribute a `pipx` solution I would be interested, but in the mean time this will do.