### PR TITLE
fix: chart-releaser action does not support tag trigger

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,9 +1,7 @@
 name: "🚀 Release Helm Chart"
 
 on:
-  push:
-    tags:
-      - "v**"
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
### Description

This PR aims to fix the incorrect use of the `tag` trigger for the `chart-releaser-action`, which unfortunately alters my release workflow.
However, I am okay with that provided it works and I don't have to maintain my own release action.

### Issue(s)

* relates to #77