### PR TITLE
feat: allow service monitor without authentication or with auth data from existing secret

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.6
+version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/uptime-kuma/readme.adoc
+++ b/charts/uptime-kuma/readme.adoc
@@ -235,6 +235,30 @@ CAUTION: You need to deploy the chart first and create a token in the uptime-kum
 |`serviceMonitor.enabled`
 |`false`
 |Specifies whether a ServiceMonitor should get created for this Chart's deployment.
+
+|`serviceMonitor.authentication.enabled`
+|`true`
+|Specifies whether the ServiceMonitor needs authentication information for the metrics endpoint.
+
+|`serviceMonitor.authentication.username`
+|`<username>`
+|The username used to authenticate to the metrics endpoint.
+
+|`serviceMonitor.authentication.password`
+|`<token>`
+|The password used to authenticate to the metrics endpoint.
+
+|`serviceMonitor.authentication.existingSecret`
+|`""`
+|An existing secret containing credentials to authenticate to the metrics endpoint.
+
+|`serviceMonitor.authentication.existingSecretUsernameKey`
+|`username`
+|The key in the existing secret, that contains the username to authenticate to the metrics endpoint.
+
+|`serviceMonitor.authentication.existingSecretPasswordKey`
+|`password`
+|The key in the existing secret, that contains the password to authenticate to the metrics endpoint.
 |===
 
 
@@ -270,4 +294,3 @@ CAUTION: You need to deploy the chart first and create a token in the uptime-kum
 |`""`
 |One or more certificates in PEM format.
 |===
-

--- a/charts/uptime-kuma/templates/secret.yaml
+++ b/charts/uptime-kuma/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled -}}
+{{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.authentication.enabled (not .Values.serviceMonitor.authentication.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +7,6 @@ metadata:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 type: Opaque
 data:
-  username: <username>
-  password: <token>
+  username: {{ .Values.serviceMonitor.authentication.username | quote }}
+  password: {{ .Values.serviceMonitor.authentication.password | quote }}
 {{- end }}

--- a/charts/uptime-kuma/templates/servicemonitor.yaml
+++ b/charts/uptime-kuma/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "uptime-kuma.fullname" . }}  
+  name: {{ include "uptime-kuma.fullname" . }}
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
 spec:
@@ -10,13 +10,24 @@ spec:
   - interval: 30s
     path: /metrics
     port: http
+    {{- if .Values.serviceMonitor.authentication.enabled }}
     basicAuth:
+      {{- if .Values.serviceMonitor.authentication.existingSecret }}
+      password:
+        name: {{ .Values.serviceMonitor.authentication.existingSecret }}
+        key: {{ .Values.serviceMonitor.authentication.existingSecretPasswordKey | default "password" }}
+      username:
+        name: {{ .Values.serviceMonitor.authentication.existingSecret }}
+        key: {{ .Values.serviceMonitor.authentication.existingSecretUsernameKey | default "username" }}
+      {{- else }}
       password:
         name: uptime-kuma-credentials
         key: password
       username:
         name: uptime-kuma-credentials
         key: username
+      {{- end }}
+    {{- end }}
   namespaceSelector: # Scrape metrics from...
     matchNames:
     - {{ include "uptime-kuma.serviceMonitorNamespace" . }}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -106,6 +106,13 @@ affinity: {}
 
 serviceMonitor:
   enabled: false
+  authentication:
+    enabled: true
+    username: <username>
+    password: <token>
+    existingSecret: ""
+    existingSecretUsernameKey: username
+    existingSecretPasswordKey: token
 
 testPod:
   image: docker.io/busybox@sha256:5eef5ed34e1e1ff0a4ae850395cbf665c4de6b4b83a32a0bc7bcb998e24e7bbb


### PR DESCRIPTION
Allow to disable authentication of the service monitor by settings `.Values.serviceAccount.authentication.enabled=false`. Also allow to provide an existing secret for the service monitor authentication.