### PR TITLE
feat: allow to provide extra certificates from existing configmap

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.6
+version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/uptime-kuma/readme.adoc
+++ b/charts/uptime-kuma/readme.adoc
@@ -269,5 +269,12 @@ CAUTION: You need to deploy the chart first and create a token in the uptime-kum
 |`extraCertificates.cacerts`
 |`""`
 |One or more certificates in PEM format.
-|===
 
+|`extraCertificates.existingConfigMap`
+|`{}`
+|The name of an existing ConfigMap, that contains one or more extra certificates in PEM format.
+
+|`extraCertificates.existingConfigMapKey`
+|`cacerts.pem`
+|The key of the existing ConfigMap, that contains the extra certificate(s) in PEM format.
+|===

--- a/charts/uptime-kuma/templates/configmap.yaml
+++ b/charts/uptime-kuma/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.extraCertificates.enabled }}
+{{- if and .Values.extraCertificates.enabled (not .Values.extraCertificates.existingConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/uptime-kuma/templates/statefulSet.yaml
+++ b/charts/uptime-kuma/templates/statefulSet.yaml
@@ -83,11 +83,19 @@ spec:
           {{- end }}
         {{- if .Values.extraCertificates.enabled }}
         - name: cacerts
+          {{- if .Values.extraCertificates.existingConfigMap }}
+          configMap:
+            name: {{ .Values.extraCertificates.existingConfigMap }}
+            items:
+              - key: {{ .Values.extraCertificates.existingConfigMapKey }}
+                path: cacerts.pem
+          {{- else }}
           configMap:
             name: uptime-kuma-configmap
             items:
               - key: cacerts.pem
                 path: cacerts.pem
+          {{- end }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -114,3 +114,5 @@ testPod:
 extraCertificates:
   enabled: false
   cacerts: ""
+  existingConfigMap: ""
+  existingConfigMapKey: cacerts.pem


### PR DESCRIPTION
Allow to provide an existing ConfigMap containing certificates in PEM format for the extra certificates.