### PR TITLE
fix: do not attempt to pin the digest for Chart.yaml

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -73,7 +73,8 @@
       ],
       "depNameTemplate": "louislam/uptime-kuma",
       "datasourceTemplate": "docker",
-      "versioningTemplate": "docker"
+      "versioningTemplate": "docker",
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
This PR aims to fix the currently failing RenovateBot bump PRs for container tags.