### PR TITLE
feat: adapt to app v2 with external mariadb

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: uptime-kuma
-description: A Helm chart for Uptime Kuma. A fancy self-hosted monitoring tool.
+description: A Helm chart for Uptime Kuma, a self-hosted service liveness monitoring tool.
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.23.16"
+appVersion: "2.0.0-beta-rootless.1"

--- a/charts/uptime-kuma/templates/secret.yaml
+++ b/charts/uptime-kuma/templates/secret.yaml
@@ -1,3 +1,4 @@
+---
 {{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.authentication.enabled (not .Values.serviceMonitor.authentication.existingSecret) -}}
 apiVersion: v1
 kind: Secret
@@ -5,8 +6,30 @@ metadata:
   name: uptime-kuma-credentials
   labels:
     {{- include "uptime-kuma.labels" . | nindent 4 }}
+  annotations:
+    description: "Credentials for Uptime Kuma service monitor"
 type: Opaque
 data:
   username: {{ .Values.serviceMonitor.authentication.username | quote }}
   password: {{ .Values.serviceMonitor.authentication.password | quote }}
+{{- end }}
+
+---
+{{- if .Values.externalDatabase.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uptime-kuma-env-credentials
+  labels:
+    {{- include "uptime-kuma.labels" . | nindent 4 }}
+  annotations:
+    description: "Credentials for an external database"
+type: Opaque
+data:
+  UPTIME_KUMA_DB_TYPE: {{ .Values.externalDatabase.type | b64enc }}
+  UPTIME_KUMA_DB_PORT: {{ .Values.externalDatabase.port | toString | b64enc }}
+  UPTIME_KUMA_DB_HOSTNAME: {{ .Values.externalDatabase.hostname | b64enc }}
+  UPTIME_KUMA_DB_USERNAME: {{ .Values.externalDatabase.username | b64enc }}
+  UPTIME_KUMA_DB_PASSWORD: {{ .Values.externalDatabase.password | b64enc }}
+  UPTIME_KUMA_DB_NAME: {{ .Values.externalDatabase.dbName | b64enc }}
 {{- end }}

--- a/charts/uptime-kuma/templates/statefulSet.yaml
+++ b/charts/uptime-kuma/templates/statefulSet.yaml
@@ -54,6 +54,16 @@ spec:
             - name: NODE_EXTRA_CA_CERTS
               value: /usr/local/share/ca-certificates/cacerts.pem
             {{- end }}
+          {{- if .Values.externalDatabase.enabled }}
+          envFrom:
+            - secretRef:
+                name: uptime-kuma-env-credentials
+          {{- end }}
+          {{- if .Values.extraCertificates.enabled }}
+          env:
+            - name: NODE_EXTRA_CA_CERTS
+              value: /usr/local/share/ca-certificates/cacerts.pem
+          {{- end }}
           ports:
             - name: http
               containerPort: 3001
@@ -72,6 +82,13 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.dnsConfig.enabled }}
+      dnsConfig:
+        {{- with .Values.dnsConfig.options }}
+        options:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+      {{- end }}
       volumes:
         - name: uptime-storage
           {{- if .Values.persistence.enabled }}
@@ -79,7 +96,7 @@ spec:
             claimName: {{ include "uptime-kuma.persistentVolumeClaimName" . }}
           {{- else }}
           emptyDir:
-            sizeLimit: 4Gi
+            sizeLimit: 1Gi
           {{- end }}
         {{- if .Values.extraCertificates.enabled }}
         - name: cacerts

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -3,18 +3,18 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: "quay.io"
-  repository: "k3rnel-pan1c/uptime-kuma"
+  registry: "docker.io"
+  repository: "louislam/uptime-kuma"
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the Chart's appVersion.
-  tag: ""
+  tag: "2.0.0-beta-rootless.1"
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-commonLabels: {}
-
+commonLabels:
+  app: uptime-kuma
 statefulSet:
   labels: {}
   annotations: {}
@@ -63,13 +63,12 @@ route:
   labels: {}
 
 ingress:
-  enabled: false
-  className: ""
+  enabled: true
+  className: "nginx"
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
+    - host: ""
       paths:
         - path: /
           pathType: ImplementationSpecific
@@ -78,17 +77,17 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 200m
-  #   memory: 256Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 30m
+    memory: 170Mi
 
 persistence:
   enabled: false
@@ -97,6 +96,21 @@ persistence:
   storageClass: ""
   annotations: {}
   labels: {}
+
+externalDatabase:
+  enabled: true
+  type: "mariadb"
+  port: 3306
+  hostname: ""
+  username: ""
+  password: ""
+  dbName: ""
+
+dnsConfig:
+  enabled: true
+  options:
+    - name: ndots
+      value: "2"
 
 nodeSelector: {}
 


### PR DESCRIPTION
It add the following changes:

- adapts the chart to beta version 2 
- adds support for mariadb credentials acquired from environment variables
- adds support for ndots in DNS config of a pod. K8s by default has 5 ndots which is a problem in some scenarios